### PR TITLE
Public accessor to AttachmentButton on MessageInput

### DIFF
--- a/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageInput.java
+++ b/chatkit/src/main/java/com/stfalcon/chatkit/messages/MessageInput.java
@@ -114,6 +114,15 @@ public class MessageInput extends RelativeLayout
     public ImageButton getButton() {
         return messageSendButton;
     }
+    
+    /**
+    * Returns `attach' button
+    *
+    * @return ImageButton
+    */
+    public ImageButton getAttachButton() {
+        return attachmentButton;
+    }
 
     @Override
     public void onClick(View view) {


### PR DESCRIPTION
Hello,
Why the send button, the inputTextView is public but not the attachButton?
I add this public accessor to get the button.

I hope will be merged soon.
Thank you.